### PR TITLE
feat: add Task Tally landing page

### DIFF
--- a/src/app/Dashboard/Dashboard.tsx
+++ b/src/app/Dashboard/Dashboard.tsx
@@ -1,10 +1,64 @@
 import * as React from 'react';
-import { PageSection, Title } from '@patternfly/react-core';
+import { Flex, FlexItem, List, ListItem, PageSection, Title } from '@patternfly/react-core';
+import logo from '../../logo.png';
 
 const Dashboard: React.FunctionComponent = () => (
-  <PageSection hasBodyWrapper={false}>
-    <Title headingLevel="h1" size="lg">Dashboard Page Title!</Title>
-  </PageSection>
-)
+  <>
+    <PageSection>
+      <Flex alignItems={{ default: 'alignItemsCenter' }}>
+        <FlexItem>
+          <img src={logo} alt="Task Tally logo" style={{ maxWidth: '150px' }} />
+        </FlexItem>
+        <FlexItem>
+          <Title headingLevel="h1" size="4xl">
+            Task Tally
+          </Title>
+          <p>
+            An estimation tool based on &quot;The art of project estimation&quot; book. This tool allows users to create
+            consulting estimates.
+          </p>
+        </FlexItem>
+      </Flex>
+    </PageSection>
+    <PageSection>
+      <div>
+        <Title headingLevel="h2" size="xl">
+          Ever wanted to propose a Container Adoption Journey, but just a little different?
+        </Title>
+        <p>We can do that, in a fraction of the time.</p>
+        <Title headingLevel="h2" size="xl">
+          What is a 3 point estimate?
+        </Title>
+        <List>
+          <ListItem>
+            An analytical and quantitative approach to estimate the Level of Effort (LOE) for projects
+          </ListItem>
+          <ListItem>Based on industry best practices</ListItem>
+          <ListItem>Reduces risk that projects will be under or over sized</ListItem>
+        </List>
+        <Title headingLevel="h2" size="xl">
+          Architects model:
+        </Title>
+        <List>
+          <ListItem>The amount of time each task will take</ListItem>
+          <ListItem>Allocate tasks to different phases of the project</ListItem>
+          <ListItem>And/or different teams working in parallel</ListItem>
+          <ListItem>How many consultants, with what titles and skill levels, are on each team</ListItem>
+        </List>
+        <Title headingLevel="h2" size="xl">
+          Allows us to quickly:
+        </Title>
+        <List>
+          <ListItem>Start with a standard solution</ListItem>
+          <ListItem>Add multiple modules and/or solutions together</ListItem>
+          <ListItem>Modify, remove, or add new tasks not in the standard solutions</ListItem>
+          <ListItem>Run “what-if” scenarios</ListItem>
+          <ListItem>How much would it cost if we had a larger/smaller team?</ListItem>
+          <ListItem>Which tasks/phases are the expensive ones, and how could we change scope to reduce cost?</ListItem>
+        </List>
+      </div>
+    </PageSection>
+  </>
+);
 
 export { Dashboard };

--- a/src/app/__snapshots__/app.test.tsx.snap
+++ b/src/app/__snapshots__/app.test.tsx.snap
@@ -192,7 +192,7 @@ exports[`App tests should render default App component 1`] = `
                 data-discover="true"
                 href="/"
               >
-                Dashboard
+                Home
               </a>
             </li>
             <li
@@ -298,14 +298,186 @@ exports[`App tests should render default App component 1`] = `
         <section
           class="pf-v6-c-page__main-section"
         >
-          <h1
-            class="pf-v6-c-title pf-m-lg"
-            data-ouia-component-id="OUIA-Generated-Title-1"
-            data-ouia-component-type="PF6/Title"
-            data-ouia-safe="true"
+          <div
+            class="pf-v6-c-page__main-body"
           >
-            Dashboard Page Title!
-          </h1>
+            <div
+              class="pf-v6-l-flex pf-m-align-items-center"
+            >
+              <div
+                class=""
+              >
+                <img
+                  alt="Task Tally logo"
+                  src="test-file-stub"
+                  style="max-width: 150px;"
+                />
+              </div>
+              <div
+                class=""
+              >
+                <h1
+                  class="pf-v6-c-title pf-m-4xl"
+                  data-ouia-component-id="OUIA-Generated-Title-1"
+                  data-ouia-component-type="PF6/Title"
+                  data-ouia-safe="true"
+                >
+                  Task Tally
+                </h1>
+                <p>
+                  An estimation tool based on "The art of project estimation" book. This tool allows users to create consulting estimates.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section
+          class="pf-v6-c-page__main-section"
+        >
+          <div
+            class="pf-v6-c-page__main-body"
+          >
+            <div>
+              <h2
+                class="pf-v6-c-title pf-m-xl"
+                data-ouia-component-id="OUIA-Generated-Title-2"
+                data-ouia-component-type="PF6/Title"
+                data-ouia-safe="true"
+              >
+                Ever wanted to propose a Container Adoption Journey, but just a little different?
+              </h2>
+              <p>
+                We can do that, in a fraction of the time.
+              </p>
+              <h2
+                class="pf-v6-c-title pf-m-xl"
+                data-ouia-component-id="OUIA-Generated-Title-3"
+                data-ouia-component-type="PF6/Title"
+                data-ouia-safe="true"
+              >
+                What is a 3 point estimate?
+              </h2>
+              <ul
+                class="pf-v6-c-list"
+              >
+                <li
+                  class=""
+                >
+                  <span>
+                    An analytical and quantitative approach to estimate the Level of Effort (LOE) for projects
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    Based on industry best practices
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    Reduces risk that projects will be under or over sized
+                  </span>
+                </li>
+              </ul>
+              <h2
+                class="pf-v6-c-title pf-m-xl"
+                data-ouia-component-id="OUIA-Generated-Title-4"
+                data-ouia-component-type="PF6/Title"
+                data-ouia-safe="true"
+              >
+                Architects model:
+              </h2>
+              <ul
+                class="pf-v6-c-list"
+              >
+                <li
+                  class=""
+                >
+                  <span>
+                    The amount of time each task will take
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    Allocate tasks to different phases of the project
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    And/or different teams working in parallel
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    How many consultants, with what titles and skill levels, are on each team
+                  </span>
+                </li>
+              </ul>
+              <h2
+                class="pf-v6-c-title pf-m-xl"
+                data-ouia-component-id="OUIA-Generated-Title-5"
+                data-ouia-component-type="PF6/Title"
+                data-ouia-safe="true"
+              >
+                Allows us to quickly:
+              </h2>
+              <ul
+                class="pf-v6-c-list"
+              >
+                <li
+                  class=""
+                >
+                  <span>
+                    Start with a standard solution
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    Add multiple modules and/or solutions together
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    Modify, remove, or add new tasks not in the standard solutions
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    Run “what-if” scenarios
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    How much would it cost if we had a larger/smaller team?
+                  </span>
+                </li>
+                <li
+                  class=""
+                >
+                  <span>
+                    Which tasks/phases are the expensive ones, and how could we change scope to reduce cost?
+                  </span>
+                </li>
+              </ul>
+            </div>
+          </div>
         </section>
       </main>
     </div>

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -27,7 +27,7 @@ describe('App tests', () => {
 
     window.dispatchEvent(new Event('resize'));
 
-    expect(screen.queryByRole('link', { name: 'Dashboard' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
   });
 
   it('should expand the sidebar on larger viewports', () => {
@@ -35,7 +35,7 @@ describe('App tests', () => {
 
     window.dispatchEvent(new Event('resize'));
 
-    expect(screen.getByRole('link', { name: 'Dashboard' })).toBeVisible();
+    expect(screen.getByRole('link', { name: 'Home' })).toBeVisible();
   });
 
   it('should hide the sidebar when clicking the nav-toggle button', async () => {
@@ -45,11 +45,10 @@ describe('App tests', () => {
 
     window.dispatchEvent(new Event('resize'));
     const button = screen.getByRole('button', { name: 'Global navigation' });
-
-    expect(screen.getByRole('link', { name: 'Dashboard' })).toBeVisible();
+    expect(screen.getByRole('link', { name: 'Home' })).toBeVisible();
 
     await user.click(button);
 
-    expect(screen.queryByRole('link', { name: 'Dashboard' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
   });
 });

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -28,9 +28,9 @@ const routes: AppRouteConfig[] = [
   {
     element: <Dashboard />,
     exact: true,
-    label: 'Dashboard',
+    label: 'Home',
     path: '/',
-    title: 'PatternFly Seed | Main Dashboard',
+    title: 'Task Tally | Home',
   },
   {
     element: <Support />,

--- a/src/index.html
+++ b/src/index.html
@@ -3,8 +3,8 @@
 
 <head>
   <meta charset="utf-8">
-  <title>Patternfly Seed</title>
-  <meta id="appName" name="application-name" content="Patternfly Seed">
+  <title>Task Tally</title>
+  <meta id="appName" name="application-name" content="Task Tally">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/images/favicon.png">
   <base href="/">


### PR DESCRIPTION
## Summary
- replace dashboard with Task Tally marketing content and logo
- set site name to Task Tally
- update navigation routes and tests

## Testing
- `npm run format`
- `npm run lint`
- `npm test`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a0e1f120b0832db09b02a8f5bd5106