### PR TITLE
feat: add Git SSH keys route

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -16,13 +16,7 @@ import {
 } from '@patternfly/react-core';
 import logo from '../../logo.png';
 import { IAppRoute, routes } from '@app/routes';
-import {
-  BarsIcon,
-  FolderOpenIcon,
-  HomeIcon,
-  ListIcon,
-  QuestionCircleIcon
-} from '@patternfly/react-icons';
+import { BarsIcon, FolderOpenIcon, HomeIcon, KeyIcon, ListIcon, QuestionCircleIcon } from '@patternfly/react-icons';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -44,7 +38,9 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
         <MastheadBrand data-codemods>
           <div style={{ display: 'flex', alignItems: 'center' }}>
             <img src={logo} alt="Task Tally Logo" style={{ height: 40, marginRight: 12 }} />
-            <span style={{ fontSize: '1.8rem', fontWeight: 700, color: 'var(--pf-t--global--text--color--regular)' }}>Task Tally</span>
+            <span style={{ fontSize: '1.8rem', fontWeight: 700, color: 'var(--pf-t--global--text--color--regular)' }}>
+              Task Tally
+            </span>
           </div>
         </MastheadBrand>
       </MastheadMain>
@@ -55,11 +51,17 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
 
   const renderNavItem = (route: IAppRoute, index: number) => (
     <NavItem key={`${route.label}-${index}`} id={`${route.label}-${index}`} isActive={route.path === location.pathname}>
-      <NavLink to={route.path.endsWith('/*') ? route.path.replace('/*', '') : route.path} style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <NavLink
+        to={route.path.endsWith('/*') ? route.path.replace('/*', '') : route.path}
+        style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+      >
         {route.label === 'Home' && <HomeIcon style={{ marginRight: 4 }} />}
         {route.label === 'Templates' && <ListIcon style={{ marginRight: 4 }} />}
         {route.label === 'Proposals' && <FolderOpenIcon style={{ marginRight: 4 }} />}
-        {!['Home', 'Templates', 'Proposals'].includes(route.label || '') && <QuestionCircleIcon style={{ marginRight: 4 }} />}
+        {route.label === 'Git SSH keys' && <KeyIcon style={{ marginRight: 4 }} />}
+        {!['Home', 'Templates', 'Proposals', 'Git SSH keys'].includes(route.label || '') && (
+          <QuestionCircleIcon style={{ marginRight: 4 }} />
+        )}
         {route.label}
       </NavLink>
     </NavItem>

--- a/src/app/GitSSHKeys/GitSSHKeys.tsx
+++ b/src/app/GitSSHKeys/GitSSHKeys.tsx
@@ -1,0 +1,13 @@
+import * as React from 'react';
+import { PageSection, Title } from '@patternfly/react-core';
+
+const GitSSHKeys: React.FunctionComponent = () => (
+  <PageSection>
+    <Title headingLevel="h1" size="xl">
+      Git SSH keys
+    </Title>
+    <p>Manage SSH keys used for Git operations.</p>
+  </PageSection>
+);
+
+export { GitSSHKeys };

--- a/src/app/__snapshots__/app.test.tsx.snap
+++ b/src/app/__snapshots__/app.test.tsx.snap
@@ -64,98 +64,20 @@ exports[`App tests should render default App component 1`] = `
           class="pf-v6-c-masthead__brand"
           data-codemods="true"
         >
-          <span
-            class="pf-v6-c-masthead__logo"
-            data-codemods="true"
+          <div
+            style="display: flex; align-items: center;"
           >
-            <svg
-              height="40px"
-              viewBox="0 0 679 158"
+            <img
+              alt="Task Tally Logo"
+              src="test-file-stub"
+              style="height: 40px; margin-right: 12px;"
+            />
+            <span
+              style="font-size: 1.8rem; font-weight: 700;"
             >
-              <title>
-                PatternFly logo
-              </title>
-              <defs>
-                <lineargradient
-                  id="linearGradient-basic-masthead"
-                  x1="68%"
-                  x2="32%"
-                  y1="2.25860997e-13%"
-                  y2="100%"
-                >
-                  <stop
-                    offset="0%"
-                    stop-color="#2B9AF3"
-                  />
-                  <stop
-                    offset="100%"
-                    stop-color="#73BCF7"
-                    stop-opacity="0.502212631"
-                  />
-                </lineargradient>
-              </defs>
-              <g
-                fill="none"
-                fill-rule="evenodd"
-                stroke="none"
-                stroke-width="1"
-              >
-                <g
-                  fill="var(--pf-t--global--text--color--regular)"
-                  fill-rule="nonzero"
-                  transform="translate(206.000000, 45.750000)"
-                >
-                  <path
-                    d="M0,65.25 L0,2.25 L33.21,2.25 C37.35,2.25 41.025,3.135 44.235,4.905 C47.445,6.675 49.98,9.09 51.84,12.15 C53.7,15.21 54.63,18.72 54.63,22.68 C54.63,26.46 53.7,29.865 51.84,32.895 C49.98,35.925 47.43,38.31 44.19,40.05 C40.95,41.79 37.29,42.66 33.21,42.66 L15.48,42.66 L15.48,65.25 L0,65.25 Z M15.48,29.88 L31.41,29.88 C33.69,29.88 35.52,29.22 36.9,27.9 C38.28,26.58 38.97,24.87 38.97,22.77 C38.97,20.61 38.28,18.855 36.9,17.505 C35.52,16.155 33.69,15.48 31.41,15.48 L15.48,15.48 L15.48,29.88 Z"
-                  />
-                  <path
-                    d="M77.04,66.06 C73.68,66.06 70.695,65.43 68.085,64.17 C65.475,62.91 63.435,61.17 61.965,58.95 C60.495,56.73 59.76,54.18 59.76,51.3 C59.76,46.74 61.485,43.215 64.935,40.725 C68.385,38.235 73.2,36.99 79.38,36.99 C83.1,36.99 86.7,37.44 90.18,38.34 L90.18,36 C90.18,31.26 87.15,28.89 81.09,28.89 C77.49,28.89 72.69,30.15 66.69,32.67 L61.47,21.96 C69.15,18.48 76.56,16.74 83.7,16.74 C90.3,16.74 95.43,18.315 99.09,21.465 C102.75,24.615 104.58,29.04 104.58,34.74 L104.58,65.25 L90.18,65.25 L90.18,62.37 C88.26,63.69 86.235,64.635 84.105,65.205 C81.975,65.775 79.62,66.06 77.04,66.06 Z M73.62,51.03 C73.62,52.53 74.28,53.7 75.6,54.54 C76.92,55.38 78.75,55.8 81.09,55.8 C84.69,55.8 87.72,55.05 90.18,53.55 L90.18,47.43 C87.42,46.71 84.54,46.35 81.54,46.35 C79.02,46.35 77.07,46.755 75.69,47.565 C74.31,48.375 73.62,49.53 73.62,51.03 Z"
-                  />
-                  <path
-                    d="M137.25,65.88 C125.73,65.88 119.97,60.84 119.97,50.76 L119.97,29.79 L110.34,29.79 L110.34,17.64 L119.97,17.64 L119.97,5.4 L134.55,2.25 L134.55,17.64 L147.87,17.64 L147.87,29.79 L134.55,29.79 L134.55,47.88 C134.55,49.98 135.015,51.465 135.945,52.335 C136.875,53.205 138.51,53.64 140.85,53.64 C143.01,53.64 145.2,53.31 147.42,52.65 L147.42,64.44 C146.1,64.86 144.42,65.205 142.38,65.475 C140.34,65.745 138.63,65.88 137.25,65.88 Z"
-                  />
-                  <path
-                    d="M177.57,65.88 C166.05,65.88 160.29,60.84 160.29,50.76 L160.29,29.79 L150.66,29.79 L150.66,17.64 L160.29,17.64 L160.29,5.4 L174.87,2.25 L174.87,17.64 L188.19,17.64 L188.19,29.79 L174.87,29.79 L174.87,47.88 C174.87,49.98 175.335,51.465 176.265,52.335 C177.195,53.205 178.83,53.64 181.17,53.64 C183.33,53.64 185.52,53.31 187.74,52.65 L187.74,64.44 C186.42,64.86 184.74,65.205 182.7,65.475 C180.66,65.745 178.95,65.88 177.57,65.88 Z"
-                  />
-                  <path
-                    d="M217.62,66.15 C212.76,66.15 208.365,65.055 204.435,62.865 C200.505,60.675 197.4,57.72 195.12,54 C192.84,50.28 191.7,46.11 191.7,41.49 C191.7,36.87 192.795,32.7 194.985,28.98 C197.175,25.26 200.16,22.305 203.94,20.115 C207.72,17.925 211.92,16.83 216.54,16.83 C221.22,16.83 225.36,17.955 228.96,20.205 C232.56,22.455 235.395,25.53 237.465,29.43 C239.535,33.33 240.57,37.8 240.57,42.84 L240.57,46.44 L206.64,46.44 C207.6,48.66 209.1,50.475 211.14,51.885 C213.18,53.295 215.58,54 218.34,54 C222.42,54 225.6,52.8 227.88,50.4 L237.51,58.95 C234.51,61.47 231.435,63.3 228.285,64.44 C225.135,65.58 221.58,66.15 217.62,66.15 Z M206.37,36.27 L226.26,36.27 C225.48,33.99 224.205,32.16 222.435,30.78 C220.665,29.4 218.61,28.71 216.27,28.71 C213.87,28.71 211.8,29.37 210.06,30.69 C208.32,32.01 207.09,33.87 206.37,36.27 Z"
-                  />
-                  <path
-                    d="M247.41,65.25 L247.41,17.64 L261.99,17.64 L261.99,22.41 C265.23,18.51 269.4,16.56 274.5,16.56 C277.08,16.62 278.91,17.01 279.99,17.73 L279.99,30.42 C277.95,29.46 275.64,28.98 273.06,28.98 C270.78,28.98 268.665,29.505 266.715,30.555 C264.765,31.605 263.19,33.09 261.99,35.01 L261.99,65.25 L247.41,65.25 Z"
-                  />
-                  <path
-                    d="M286.29,65.25 L286.29,17.64 L300.87,17.64 L300.87,20.88 C304.47,18.12 308.73,16.74 313.65,16.74 C317.37,16.74 320.655,17.55 323.505,19.17 C326.355,20.79 328.59,23.04 330.21,25.92 C331.83,28.8 332.64,32.13 332.64,35.91 L332.64,65.25 L318.06,65.25 L318.06,37.89 C318.06,35.25 317.28,33.15 315.72,31.59 C314.16,30.03 312.06,29.25 309.42,29.25 C305.76,29.25 302.91,30.51 300.87,33.03 L300.87,65.25 L286.29,65.25 Z"
-                  />
-                  <polygon
-                    points="342 65.25 342 2.25 392.04 2.25 392.04 15.66 357.48 15.66 357.48 27.45 380.52 27.45 380.52 40.41 357.48 40.41 357.48 65.25"
-                  />
-                  <polygon
-                    points="399.96 65.25 399.96 2.25 414.54 0 414.54 65.25"
-                  />
-                  <path
-                    d="M429.21,84.69 C428.07,84.69 426.96,84.645 425.88,84.555 C424.8,84.465 423.9,84.33 423.18,84.15 L423.18,71.73 C424.38,71.97 425.88,72.09 427.68,72.09 C432.36,72.09 435.51,70.05 437.13,65.97 L437.13,65.88 L418.86,17.64 L434.97,17.64 L445.5,47.61 L457.74,17.64 L473.49,17.64 L452.16,67.68 C450.42,71.82 448.5,75.135 446.4,77.625 C444.3,80.115 441.87,81.915 439.11,83.025 C436.35,84.135 433.05,84.69 429.21,84.69 Z"
-                  />
-                </g>
-                <g
-                  transform="translate(0.000000, 0.000000)"
-                >
-                  <path
-                    d="M61.826087,0 L158,0 L158,96.173913 L147.695652,96.173913 C100.271201,96.173913 61.826087,57.7287992 61.826087,10.3043478 L61.826087,0 L61.826087,0 Z"
-                    fill="#0066CC"
-                  />
-                  <path
-                    d="M158,3.43478261 L65.2608696,158 L138,158 C149.045695,158 158,149.045695 158,138 L158,3.43478261 L158,3.43478261 Z"
-                    fill="url(#linearGradient-basic-masthead)"
-                  />
-                  <path
-                    d="M123.652174,-30.9130435 L30.9130435,123.652174 L103.652174,123.652174 C114.697869,123.652174 123.652174,114.697869 123.652174,103.652174 L123.652174,-30.9130435 L123.652174,-30.9130435 Z"
-                    fill="url(#linearGradient-basic-masthead)"
-                    transform="translate(77.282609, 46.369565) scale(1, -1) rotate(90.000000) translate(-77.282609, -46.369565) "
-                  />
-                </g>
-              </g>
-            </svg>
-          </span>
+              Task Tally
+            </span>
+          </div>
         </div>
       </div>
     </header>
@@ -191,7 +113,22 @@ exports[`App tests should render default App component 1`] = `
                 class="pf-v6-c-nav__link pf-m-current active"
                 data-discover="true"
                 href="/"
+                style="display: flex; align-items: center; gap: 8px;"
               >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="margin-right: 4px;"
+                  viewBox="0 0 576 512"
+                  width="1em"
+                >
+                  <path
+                    d="M280.37 148.26L96 300.11V464a16 16 0 0 0 16 16l112.06-.29a16 16 0 0 0 15.92-16V368a16 16 0 0 1 16-16h64a16 16 0 0 1 16 16v95.64a16 16 0 0 0 16 16.05L464 480a16 16 0 0 0 16-16V300L295.67 148.26a12.19 12.19 0 0 0-15.3 0zM571.6 251.47L488 182.56V44.05a12 12 0 0 0-12-12h-56a12 12 0 0 0-12 12v72.61L318.47 43a48 48 0 0 0-61 0L4.34 251.47a12 12 0 0 0-1.6 16.9l25.5 31A12 12 0 0 0 45.15 301l235.22-193.74a12.19 12.19 0 0 1 15.3 0L530.9 301a12 12 0 0 0 16.9-1.6l25.5-31a12 12 0 0 0-1.7-16.93z"
+                  />
+                </svg>
                 Home
               </a>
             </li>
@@ -205,7 +142,22 @@ exports[`App tests should render default App component 1`] = `
                 class="pf-v6-c-nav__link"
                 data-discover="true"
                 href="/templates"
+                style="display: flex; align-items: center; gap: 8px;"
               >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="margin-right: 4px;"
+                  viewBox="0 0 512 512"
+                  width="1em"
+                >
+                  <path
+                    d="M80 368H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm0-320H16A16 16 0 0 0 0 64v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16V64a16 16 0 0 0-16-16zm0 160H16a16 16 0 0 0-16 16v64a16 16 0 0 0 16 16h64a16 16 0 0 0 16-16v-64a16 16 0 0 0-16-16zm416 176H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16zm0-320H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16V80a16 16 0 0 0-16-16zm0 160H176a16 16 0 0 0-16 16v32a16 16 0 0 0 16 16h320a16 16 0 0 0 16-16v-32a16 16 0 0 0-16-16z"
+                  />
+                </svg>
                 Templates
               </a>
             </li>
@@ -219,8 +171,52 @@ exports[`App tests should render default App component 1`] = `
                 class="pf-v6-c-nav__link"
                 data-discover="true"
                 href="/proposals"
+                style="display: flex; align-items: center; gap: 8px;"
               >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="margin-right: 4px;"
+                  viewBox="0 0 576 512"
+                  width="1em"
+                >
+                  <path
+                    d="M572.694 292.093L500.27 416.248A63.997 63.997 0 0 1 444.989 448H45.025c-18.523 0-30.064-20.093-20.731-36.093l72.424-124.155A64 64 0 0 1 152 256h399.964c18.523 0 30.064 20.093 20.73 36.093zM152 224h328v-48c0-26.51-21.49-48-48-48H272l-64-64H48C21.49 64 0 85.49 0 112v278.046l69.077-118.418C86.214 242.25 117.989 224 152 224z"
+                  />
+                </svg>
                 Proposals
+              </a>
+            </li>
+            <li
+              class="pf-v6-c-nav__item"
+              data-ouia-component-id="OUIA-Generated-NavItem-4"
+              data-ouia-component-type="PF6/NavItem"
+              data-ouia-safe="true"
+            >
+              <a
+                class="pf-v6-c-nav__link"
+                data-discover="true"
+                href="/git-ssh-keys"
+                style="display: flex; align-items: center; gap: 8px;"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="pf-v6-svg"
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style="margin-right: 4px;"
+                  viewBox="0 0 1024 1024"
+                  width="1em"
+                >
+                  <path
+                    d="M802,320 C748.980664,320 706,277.019336 706,224 C706,170.980664 748.980664,128 802,128 C855.019336,128 898,170.980664 898,224 C898,277.019336 855.019336,320 802,320 M704,0 C527.3,0 384,143.3 384,320 C383.937788,357.490503 390.505571,394.696657 403.4,429.9 L0,824.1 L0,1024 L192,1024 L192,896 L320,896 L320,768 L448,768 L597,622 C596.906403,621.881923 596.838304,621.745723 596.8,621.6 C631.220126,633.811107 667.47802,640.034477 704,640 C880.7,640 1024,496.7 1024,320 C1024,143.3 880.7,0 704,0"
+                  />
+                </svg>
+                Git SSH keys
               </a>
             </li>
           </ul>
@@ -272,6 +268,365 @@ exports[`App tests should render default App component 1`] = `
           </div>
         </section>
         <section
+          class="pf-v6-c-page__main-section pf-m-secondary"
+        >
+          <div
+            class="pf-v6-c-page__main-body"
+          >
+            <div
+              class="pf-v6-l-flex pf-m-column pf-m-align-items-center"
+            >
+              <h2
+                class="pf-v6-c-title pf-m-lg"
+                data-ouia-component-id="OUIA-Generated-Title-2"
+                data-ouia-component-type="PF6/Title"
+                data-ouia-safe="true"
+                style="text-align: center; margin-bottom: 1rem;"
+              >
+                Templates & Proposals Overview
+              </h2>
+              <svg
+                height="260"
+                style="max-width: 100%; height: auto; margin-bottom: 1rem;"
+                viewBox="0 0 800 260"
+                width="800"
+              >
+                <rect
+                  fill="#e3f2fd"
+                  height="80"
+                  rx="15"
+                  stroke="#1976d2"
+                  stroke-width="2"
+                  width="240"
+                  x="3"
+                  y="40"
+                />
+                <text
+                  fill="#1976d2"
+                  font-size="18"
+                  font-weight="bold"
+                  text-anchor="middle"
+                  x="140"
+                  y="70"
+                >
+                  Templates
+                </text>
+                <text
+                  fill="#1976d2"
+                  font-size="13"
+                  text-anchor="middle"
+                  x="122"
+                  y="95"
+                >
+                  Reusable groups of tasks, outcomes, etc.
+                </text>
+                <polygon
+                  fill="#1976d2"
+                  points="250,80 290,80 290,70 320,90 290,110 290,100 250,100"
+                />
+                <text
+                  fill="#1976d2"
+                  font-size="12"
+                  text-anchor="middle"
+                  x="285"
+                  y="65"
+                >
+                  can create
+                </text>
+                <rect
+                  fill="#fff3e0"
+                  height="80"
+                  rx="15"
+                  stroke="#f57c00"
+                  stroke-width="2"
+                  width="240"
+                  x="320"
+                  y="40"
+                />
+                <text
+                  fill="#f57c00"
+                  font-size="18"
+                  font-weight="bold"
+                  text-anchor="middle"
+                  x="440"
+                  y="70"
+                >
+                  Proposals
+                </text>
+                <text
+                  fill="#f57c00"
+                  font-size="13"
+                  text-anchor="middle"
+                  x="440"
+                  y="95"
+                >
+                  Estimate project effort
+                </text>
+                <text
+                  fill="#f57c00"
+                  font-size="13"
+                  text-anchor="middle"
+                  x="440"
+                  y="112"
+                >
+                  Composed of templates + custom tasks
+                </text>
+                <rect
+                  fill="#fce4ec"
+                  height="60"
+                  rx="12"
+                  stroke="#c2185b"
+                  stroke-width="2"
+                  width="210"
+                  x="350"
+                  y="140"
+                />
+                <text
+                  fill="#c2185b"
+                  font-size="15"
+                  font-weight="bold"
+                  text-anchor="middle"
+                  x="460"
+                  y="170"
+                >
+                  Additional Tasks/Elements
+                </text>
+                <text
+                  fill="#c2185b"
+                  font-size="12"
+                  text-anchor="middle"
+                  x="460"
+                  y="190"
+                >
+                  Specific to each project proposal
+                </text>
+                <polygon
+                  fill="#c2185b"
+                  points="460,140 460,130 455,130 460,120 465,130 460,130"
+                />
+              </svg>
+              <div
+                style="max-width: 500px; text-align: center;"
+              >
+                <p
+                  style="font-size: 1rem;"
+                >
+                  <strong>
+                    Templates
+                  </strong>
+                   describe reusable groups of tasks, outcomes, and more.
+                  <br />
+                  <strong>
+                    Proposals
+                  </strong>
+                   estimate project effort, combining one or more templates and additional tasks unique to the project.
+                </p>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section
+          class="pf-v6-c-page__main-section"
+        >
+          <div
+            class="pf-v6-c-page__main-body"
+          >
+            <div
+              class="pf-v6-l-flex pf-m-justify-content-center"
+            >
+              <div
+                class=""
+              >
+                <h2
+                  class="pf-v6-c-title pf-m-lg"
+                  data-ouia-component-id="OUIA-Generated-Title-3"
+                  data-ouia-component-type="PF6/Title"
+                  data-ouia-safe="true"
+                  style="text-align: center; margin-bottom: 1rem;"
+                >
+                  How Task Tally Works
+                </h2>
+                <div
+                  class="pf-v6-l-flex pf-m-space-items-lg"
+                >
+                  <div
+                    class=""
+                  >
+                    <div
+                      style="text-align: center;"
+                    >
+                      <svg
+                        fill="none"
+                        height="64"
+                        viewBox="0 0 64 64"
+                        width="64"
+                      >
+                        <circle
+                          cx="32"
+                          cy="32"
+                          fill="#E0E7FF"
+                          r="32"
+                        />
+                        <text
+                          fill="#3C3C3C"
+                          font-size="24"
+                          text-anchor="middle"
+                          x="32"
+                          y="38"
+                        >
+                          1
+                        </text>
+                      </svg>
+                      <h3
+                        class="pf-v6-c-title pf-m-md"
+                        data-ouia-component-id="OUIA-Generated-Title-4"
+                        data-ouia-component-type="PF6/Title"
+                        data-ouia-safe="true"
+                      >
+                        Define Tasks
+                      </h3>
+                      <p
+                        style="max-width: 120px; margin: 0px auto;"
+                      >
+                        List all project tasks and phases.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    <div
+                      style="text-align: center;"
+                    >
+                      <svg
+                        fill="none"
+                        height="64"
+                        viewBox="0 0 64 64"
+                        width="64"
+                      >
+                        <circle
+                          cx="32"
+                          cy="32"
+                          fill="#C7F9E9"
+                          r="32"
+                        />
+                        <text
+                          fill="#3C3C3C"
+                          font-size="24"
+                          text-anchor="middle"
+                          x="32"
+                          y="38"
+                        >
+                          2
+                        </text>
+                      </svg>
+                      <h3
+                        class="pf-v6-c-title pf-m-md"
+                        data-ouia-component-id="OUIA-Generated-Title-5"
+                        data-ouia-component-type="PF6/Title"
+                        data-ouia-safe="true"
+                      >
+                        Estimate Effort
+                      </h3>
+                      <p
+                        style="max-width: 120px; margin: 0px auto;"
+                      >
+                        Use 3-point estimates to assess LOE and risk.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    <div
+                      style="text-align: center;"
+                    >
+                      <svg
+                        fill="none"
+                        height="64"
+                        viewBox="0 0 64 64"
+                        width="64"
+                      >
+                        <circle
+                          cx="32"
+                          cy="32"
+                          fill="#FFD6E0"
+                          r="32"
+                        />
+                        <text
+                          fill="#3C3C3C"
+                          font-size="24"
+                          text-anchor="middle"
+                          x="32"
+                          y="38"
+                        >
+                          3
+                        </text>
+                      </svg>
+                      <h3
+                        class="pf-v6-c-title pf-m-md"
+                        data-ouia-component-id="OUIA-Generated-Title-6"
+                        data-ouia-component-type="PF6/Title"
+                        data-ouia-safe="true"
+                      >
+                        Model Teams
+                      </h3>
+                      <p
+                        style="max-width: 120px; margin: 0px auto;"
+                      >
+                        Assign consultants, teams, and skill levels.
+                      </p>
+                    </div>
+                  </div>
+                  <div
+                    class=""
+                  >
+                    <div
+                      style="text-align: center;"
+                    >
+                      <svg
+                        fill="none"
+                        height="64"
+                        viewBox="0 0 64 64"
+                        width="64"
+                      >
+                        <circle
+                          cx="32"
+                          cy="32"
+                          fill="#FFFACD"
+                          r="32"
+                        />
+                        <text
+                          fill="#3C3C3C"
+                          font-size="24"
+                          text-anchor="middle"
+                          x="32"
+                          y="38"
+                        >
+                          4
+                        </text>
+                      </svg>
+                      <h3
+                        class="pf-v6-c-title pf-m-md"
+                        data-ouia-component-id="OUIA-Generated-Title-7"
+                        data-ouia-component-type="PF6/Title"
+                        data-ouia-safe="true"
+                      >
+                        Analyze & Adjust
+                      </h3>
+                      <p
+                        style="max-width: 120px; margin: 0px auto;"
+                      >
+                        Run scenarios, adjust scope, and optimize cost.
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+        <section
           class="pf-v6-c-page__main-section"
         >
           <div
@@ -280,7 +635,7 @@ exports[`App tests should render default App component 1`] = `
             <div>
               <h2
                 class="pf-v6-c-title pf-m-xl"
-                data-ouia-component-id="OUIA-Generated-Title-2"
+                data-ouia-component-id="OUIA-Generated-Title-8"
                 data-ouia-component-type="PF6/Title"
                 data-ouia-safe="true"
               >
@@ -291,7 +646,7 @@ exports[`App tests should render default App component 1`] = `
               </p>
               <h2
                 class="pf-v6-c-title pf-m-xl"
-                data-ouia-component-id="OUIA-Generated-Title-3"
+                data-ouia-component-id="OUIA-Generated-Title-9"
                 data-ouia-component-type="PF6/Title"
                 data-ouia-safe="true"
               >
@@ -324,7 +679,7 @@ exports[`App tests should render default App component 1`] = `
               </ul>
               <h2
                 class="pf-v6-c-title pf-m-xl"
-                data-ouia-component-id="OUIA-Generated-Title-4"
+                data-ouia-component-id="OUIA-Generated-Title-10"
                 data-ouia-component-type="PF6/Title"
                 data-ouia-safe="true"
               >
@@ -364,7 +719,7 @@ exports[`App tests should render default App component 1`] = `
               </ul>
               <h2
                 class="pf-v6-c-title pf-m-xl"
-                data-ouia-component-id="OUIA-Generated-Title-5"
+                data-ouia-component-id="OUIA-Generated-Title-11"
                 data-ouia-component-type="PF6/Title"
                 data-ouia-safe="true"
               >

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -25,6 +25,14 @@ describe('App tests', () => {
     expect(screen.getByRole('link', { name: 'Home' })).toBeVisible();
   });
 
+  it('should include Git SSH keys in the navigation', () => {
+    render(<App />);
+
+    window.dispatchEvent(new Event('resize'));
+
+    expect(screen.getByRole('link', { name: 'Git SSH keys' })).toBeVisible();
+  });
+
   it('should hide the sidebar when clicking the nav-toggle button', async () => {
     const user = userEvent.setup();
 

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -4,6 +4,7 @@ import { Home } from '@app/Home/Home';
 import { Templates } from '@app/Templates/Templates';
 import { Proposals } from '@app/Proposals/Proposals';
 import { NotFound } from '@app/NotFound/NotFound';
+import { GitSSHKeys } from '@app/GitSSHKeys/GitSSHKeys';
 
 export interface IAppRoute {
   label?: string; // Excluding the label will exclude the route from the nav sidebar in AppLayout
@@ -37,6 +38,13 @@ const routes: AppRouteConfig[] = [
     label: 'Proposals',
     path: '/proposals',
     title: 'Task Tally | Proposals',
+  },
+  {
+    element: <GitSSHKeys />,
+    exact: true,
+    label: 'Git SSH keys',
+    path: '/git-ssh-keys',
+    title: 'Task Tally | Git SSH keys',
   },
 ];
 


### PR DESCRIPTION
## Summary
- add Git SSH keys page and route
- show key icon in sidebar navigation
- test navigation for Git SSH keys link

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a135f309d0832db80afe24e9e399cc