### PR TITLE
fix: show landing background and enable login

### DIFF
--- a/src/app/LandingPage/LandingPage.tsx
+++ b/src/app/LandingPage/LandingPage.tsx
@@ -3,36 +3,30 @@ import { BackgroundImage, Bullseye, Button, Stack, StackItem, Title } from '@pat
 import { GoogleIcon } from '@patternfly/react-icons';
 import pfbg from '@assets/images/PF-Backdrop.svg';
 
-const backendUrl = process.env.TASK_TALLY_BACKEND || '';
+const backendUrl = process.env.TASK_TALLY_BACKEND || '/api';
 
-const LandingPage: React.FunctionComponent = () => {
-  const handleSignIn = () => {
-    window.location.href = `${backendUrl}/auth/google`;
-  };
-
-  return (
-    <BackgroundImage src={pfbg} style={{ minHeight: '100vh' }}>
-      <Bullseye>
-        <Stack hasGutter>
-          <StackItem>
-            <Title headingLevel="h1" size="4xl">
-              Task Tally
-            </Title>
-          </StackItem>
-          <StackItem>
-            <Title headingLevel="h2" size="lg">
-              Consulting Templates & Task Management
-            </Title>
-          </StackItem>
-          <StackItem>
-            <Button icon={<GoogleIcon />} variant="primary" size="lg" onClick={handleSignIn}>
-              Sign in with Google
-            </Button>
-          </StackItem>
-        </Stack>
-      </Bullseye>
-    </BackgroundImage>
-  );
-};
+const LandingPage: React.FunctionComponent = () => (
+  <BackgroundImage src={pfbg}>
+    <Bullseye style={{ minHeight: '100vh' }}>
+      <Stack hasGutter>
+        <StackItem>
+          <Title headingLevel="h1" size="4xl">
+            Task Tally
+          </Title>
+        </StackItem>
+        <StackItem>
+          <Title headingLevel="h2" size="lg">
+            Consulting Templates & Task Management
+          </Title>
+        </StackItem>
+        <StackItem>
+          <Button icon={<GoogleIcon />} variant="primary" size="lg" component="a" href={`${backendUrl}/auth/google`}>
+            Sign in with Google
+          </Button>
+        </StackItem>
+      </Stack>
+    </Bullseye>
+  </BackgroundImage>
+);
 
 export { LandingPage };

--- a/src/app/__snapshots__/app.test.tsx.snap
+++ b/src/app/__snapshots__/app.test.tsx.snap
@@ -4,10 +4,11 @@ exports[`App tests should render landing page when unauthenticated 1`] = `
 <DocumentFragment>
   <div
     class="pf-v6-c-background-image"
-    style="min-height: 100vh;"
+    style="--pf-v6-c-background-image--BackgroundImage: url(test-file-stub);"
   >
     <div
       class="pf-v6-l-bullseye"
+      style="min-height: 100vh;"
     >
       <div
         class="pf-v6-l-stack pf-m-gutter"
@@ -39,13 +40,13 @@ exports[`App tests should render landing page when unauthenticated 1`] = `
         <div
           class="pf-v6-l-stack__item"
         >
-          <button
+          <a
             aria-disabled="false"
             class="pf-v6-c-button pf-m-primary pf-m-display-lg"
             data-ouia-component-id="OUIA-Generated-Button-primary-1"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
-            type="button"
+            href="/api/auth/google"
           >
             <span
               class="pf-v6-c-button__icon pf-m-start"
@@ -69,7 +70,7 @@ exports[`App tests should render landing page when unauthenticated 1`] = `
             >
               Sign in with Google
             </span>
-          </button>
+          </a>
         </div>
       </div>
     </div>

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -9,7 +9,7 @@ describe('App tests', () => {
     const { asFragment } = render(<App />);
 
     expect(screen.getByRole('heading', { name: 'Task Tally' })).toBeVisible();
-    expect(screen.getByRole('button', { name: /sign in with google/i })).toBeVisible();
+    expect(screen.getByRole('link', { name: /sign in with google/i })).toBeVisible();
     expect(asFragment()).toMatchSnapshot();
   });
 


### PR DESCRIPTION
## Summary
- ensure landing page background image is displayed
- link login button to backend auth endpoint
- adjust tests for new login link

## Testing
- `npm test`
- `npm run lint`
- `npm run type-check`


------
https://chatgpt.com/codex/tasks/task_e_68a21c35d1f4832d9881006eecd08874