### PR TITLE
feat: secure routes with google auth

### DIFF
--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { NavLink, useLocation } from 'react-router-dom';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import {
   Button,
   Masthead,
   MastheadBrand,
+  MastheadContent,
   MastheadMain,
   MastheadToggle,
   Nav,
@@ -17,6 +18,7 @@ import {
 import logo from '../../logo.png';
 import { IAppRoute, routes } from '@app/routes';
 import { BarsIcon, FolderOpenIcon, HomeIcon, KeyIcon, ListIcon, QuestionCircleIcon } from '@patternfly/react-icons';
+import { useAuth } from '@app/utils/AuthContext';
 
 interface IAppLayout {
   children: React.ReactNode;
@@ -24,6 +26,12 @@ interface IAppLayout {
 
 const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
   const [sidebarOpen, setSidebarOpen] = React.useState(true);
+  const { logout } = useAuth();
+  const navigate = useNavigate();
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
   const masthead = (
     <Masthead>
       <MastheadMain>
@@ -44,6 +52,11 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
           </div>
         </MastheadBrand>
       </MastheadMain>
+      <MastheadContent>
+        <Button variant="link" onClick={handleLogout}>
+          Sign out
+        </Button>
+      </MastheadContent>
     </Masthead>
   );
 
@@ -58,8 +71,8 @@ const AppLayout: React.FunctionComponent<IAppLayout> = ({ children }) => {
         {route.label === 'Home' && <HomeIcon style={{ marginRight: 4 }} />}
         {route.label === 'Templates' && <ListIcon style={{ marginRight: 4 }} />}
         {route.label === 'Proposals' && <FolderOpenIcon style={{ marginRight: 4 }} />}
-        {route.label === 'Git SSH keys' && <KeyIcon style={{ marginRight: 4 }} />}
-        {!['Home', 'Templates', 'Proposals', 'Git SSH keys'].includes(route.label || '') && (
+        {route.label === 'Credentials' && <KeyIcon style={{ marginRight: 4 }} />}
+        {!['Home', 'Templates', 'Proposals', 'Credentials'].includes(route.label || '') && (
           <QuestionCircleIcon style={{ marginRight: 4 }} />
         )}
         {route.label}

--- a/src/app/GitSSHKeys/__tests__/sshkeys.ui.test.tsx
+++ b/src/app/GitSSHKeys/__tests__/sshkeys.ui.test.tsx
@@ -19,9 +19,9 @@ jest.mock('@api/credentials/service', () => {
 
 const renderPage = () =>
   render(
-    <MemoryRouter initialEntries={['/git-ssh-keys']}>
+    <MemoryRouter initialEntries={['/credentials']}>
       <Routes>
-        <Route path="/git-ssh-keys" element={<GitSSHKeys />} />
+        <Route path="/credentials" element={<GitSSHKeys />} />
       </Routes>
     </MemoryRouter>,
   );

--- a/src/app/LandingPage/LandingPage.tsx
+++ b/src/app/LandingPage/LandingPage.tsx
@@ -2,31 +2,33 @@ import * as React from 'react';
 import { BackgroundImage, Bullseye, Button, Stack, StackItem, Title } from '@patternfly/react-core';
 import { GoogleIcon } from '@patternfly/react-icons';
 import pfbg from '@assets/images/PF-Backdrop.svg';
+import { useAuth } from '@app/utils/AuthContext';
 
-const backendUrl = process.env.TASK_TALLY_BACKEND || '/api';
-
-const LandingPage: React.FunctionComponent = () => (
-  <BackgroundImage src={pfbg}>
-    <Bullseye style={{ minHeight: '100vh' }}>
-      <Stack hasGutter>
-        <StackItem>
-          <Title headingLevel="h1" size="4xl">
-            Task Tally
-          </Title>
-        </StackItem>
-        <StackItem>
-          <Title headingLevel="h2" size="lg">
-            Consulting Templates & Task Management
-          </Title>
-        </StackItem>
-        <StackItem>
-          <Button icon={<GoogleIcon />} variant="primary" size="lg" component="a" href={`${backendUrl}/auth/google`}>
-            Sign in with Google
-          </Button>
-        </StackItem>
-      </Stack>
-    </Bullseye>
-  </BackgroundImage>
-);
+const LandingPage: React.FunctionComponent = () => {
+  const { login } = useAuth();
+  return (
+    <BackgroundImage src={pfbg}>
+      <Bullseye style={{ minHeight: '100vh' }}>
+        <Stack hasGutter>
+          <StackItem>
+            <Title headingLevel="h1" size="4xl">
+              Task Tally
+            </Title>
+          </StackItem>
+          <StackItem>
+            <Title headingLevel="h2" size="lg">
+              Consulting Templates & Task Management
+            </Title>
+          </StackItem>
+          <StackItem>
+            <Button icon={<GoogleIcon />} variant="primary" size="lg" onClick={login}>
+              Sign in with Google
+            </Button>
+          </StackItem>
+        </Stack>
+      </Bullseye>
+    </BackgroundImage>
+  );
+};
 
 export { LandingPage };

--- a/src/app/__snapshots__/app.test.tsx.snap
+++ b/src/app/__snapshots__/app.test.tsx.snap
@@ -40,13 +40,13 @@ exports[`App tests should render landing page when unauthenticated 1`] = `
         <div
           class="pf-v6-l-stack__item"
         >
-          <a
+          <button
             aria-disabled="false"
             class="pf-v6-c-button pf-m-primary pf-m-display-lg"
             data-ouia-component-id="OUIA-Generated-Button-primary-1"
             data-ouia-component-type="PF6/Button"
             data-ouia-safe="true"
-            href="/api/auth/google"
+            type="button"
           >
             <span
               class="pf-v6-c-button__icon pf-m-start"
@@ -70,7 +70,7 @@ exports[`App tests should render landing page when unauthenticated 1`] = `
             >
               Sign in with Google
             </span>
-          </a>
+          </button>
         </div>
       </div>
     </div>

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -9,7 +9,7 @@ describe('App tests', () => {
     const { asFragment } = render(<App />);
 
     expect(screen.getByRole('heading', { name: 'Task Tally' })).toBeVisible();
-    expect(screen.getByRole('link', { name: /sign in with google/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /sign in with google/i })).toBeVisible();
     expect(asFragment()).toMatchSnapshot();
   });
 
@@ -32,7 +32,7 @@ describe('App tests', () => {
 
     window.dispatchEvent(new Event('resize'));
 
-    expect(screen.getByRole('link', { name: 'Git SSH keys' })).toBeVisible();
+    expect(screen.getByRole('link', { name: 'Credentials' })).toBeVisible();
   });
 
   it('should hide the sidebar when clicking the nav-toggle button', async () => {

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -1,31 +1,33 @@
 import * as React from 'react';
 import '@patternfly/react-core/dist/styles/base.css';
-import { Navigate, Route, BrowserRouter as Router, Routes } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { AppLayout } from '@app/AppLayout/AppLayout';
 import { AppRoutes } from '@app/routes';
 import { LandingPage } from '@app/LandingPage/LandingPage';
 import '@app/app.css';
+import { AuthProvider, useAuth } from '@app/utils/AuthContext';
 
 interface AppProps {
   mockAuthenticated?: boolean;
 }
 
-const App: React.FunctionComponent<AppProps> = ({ mockAuthenticated }) => {
-  const isAuthenticated = mockAuthenticated ?? false;
-  return (
-    <Router>
-      {isAuthenticated ? (
-        <AppLayout>
-          <AppRoutes />
-        </AppLayout>
-      ) : (
-        <Routes>
-          <Route path="/" element={<LandingPage />} />
-          <Route path="*" element={<Navigate to="/" replace />} />
-        </Routes>
-      )}
-    </Router>
+const AppContent: React.FunctionComponent = () => {
+  const { isAuthenticated } = useAuth();
+  return isAuthenticated ? (
+    <AppLayout>
+      <AppRoutes />
+    </AppLayout>
+  ) : (
+    <LandingPage />
   );
 };
+
+const App: React.FunctionComponent<AppProps> = ({ mockAuthenticated }) => (
+  <AuthProvider mockAuthenticated={mockAuthenticated}>
+    <Router>
+      <AppContent />
+    </Router>
+  </AuthProvider>
+);
 
 export default App;

--- a/src/app/routes.tsx
+++ b/src/app/routes.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import { Home } from '@app/Home/Home';
 import { Templates } from '@app/Templates/Templates';
 import { Proposals } from '@app/Proposals/Proposals';
@@ -23,7 +23,7 @@ const routes: AppRouteConfig[] = [
     element: <Home />,
     exact: true,
     label: 'Home',
-    path: '/',
+    path: '/home',
     title: 'Task Tally | Home',
   },
   {
@@ -42,9 +42,9 @@ const routes: AppRouteConfig[] = [
   {
     element: <GitSSHKeys />,
     exact: true,
-    label: 'Git SSH keys',
-    path: '/git-ssh-keys',
-    title: 'Task Tally | Git SSH keys',
+    label: 'Credentials',
+    path: '/credentials',
+    title: 'Task Tally | Credentials',
   },
 ];
 
@@ -53,6 +53,7 @@ const AppRoutes = (): React.ReactElement => (
     {routes.map(({ path, element }, idx) => (
       <Route path={path} element={element} key={idx} />
     ))}
+    <Route path="/" element={<Navigate to="/home" replace />} />
     <Route element={<NotFound />} />
   </Routes>
 );

--- a/src/app/utils/AuthContext.tsx
+++ b/src/app/utils/AuthContext.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+
+interface User {
+  email?: string;
+  name?: string;
+  picture?: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  token: string | null;
+  isAuthenticated: boolean;
+  login: () => void;
+  logout: () => void;
+}
+
+const AuthContext = React.createContext<AuthContextType>({
+  user: null,
+  token: null,
+  isAuthenticated: false,
+  login: () => undefined,
+  logout: () => undefined,
+});
+
+const clientId = process.env.GOOGLE_CLIENT_ID || '';
+
+interface AuthProviderProps {
+  children: React.ReactNode;
+  mockAuthenticated?: boolean;
+}
+
+type GoogleId = {
+  accounts: {
+    id: {
+      initialize: (opts: { client_id: string; callback: (res: { credential: string }) => void }) => void;
+      prompt: () => void;
+    };
+  };
+};
+
+const AuthProvider: React.FunctionComponent<AuthProviderProps> = ({ children, mockAuthenticated }) => {
+  const [user, setUser] = React.useState<User | null>(null);
+  const [token, setToken] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    if (mockAuthenticated) {
+      const mockUser = { name: 'Mock User', email: 'mock@example.com' };
+      setUser(mockUser);
+      setToken('mock-token');
+      return;
+    }
+    const storedUser = localStorage.getItem('auth_user');
+    const storedToken = localStorage.getItem('auth_token');
+    if (storedUser && storedToken) {
+      setUser(JSON.parse(storedUser));
+      setToken(storedToken);
+    }
+  }, [mockAuthenticated]);
+
+  const login = () => {
+    const google = (window as Window & { google?: GoogleId }).google;
+    if (google?.accounts.id) {
+      google.accounts.id.initialize({
+        client_id: clientId,
+        callback: (res: { credential: string }) => {
+          try {
+            const payload = JSON.parse(atob(res.credential.split('.')[1]));
+            setUser(payload);
+            setToken(res.credential);
+            localStorage.setItem('auth_user', JSON.stringify(payload));
+            localStorage.setItem('auth_token', res.credential);
+            window.location.href = '/home';
+          } catch {
+            // ignore parsing errors
+          }
+        },
+      });
+      google.accounts.id.prompt();
+    }
+  };
+
+  const logout = () => {
+    setUser(null);
+    setToken(null);
+    localStorage.removeItem('auth_user');
+    localStorage.removeItem('auth_token');
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, token, isAuthenticated: !!user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+const useAuth = (): AuthContextType => React.useContext(AuthContext);
+
+export { AuthProvider, useAuth };

--- a/src/index.html
+++ b/src/index.html
@@ -8,6 +8,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <link rel="icon" type="image/svg+xml" href="/images/favicon.png">
   <base href="/">
+  <script src="https://accounts.google.com/gsi/client" async defer></script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- gate core routes behind Google authentication
- add Google sign-in flow and sign-out support
- redirect unauthenticated users to landing page

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a220d850bc832d9c248b819e521594