### PR TITLE
feat: integrate keycloak auth

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,0 @@
-TASK_TALLY_BACKEND=http://localhost:8080
-
-KEYCLOAK_URL=http://localhost:8080
-KEYCLOAK_REALM=task-tally-realm
-KEYCLOAK_CLIENT_ID=task-tally
-KEYCLOAK_SILENT_CHECK_PATH=/silent-check-sso.html
-KEYCLOAK_ONLOAD=check-sso
-

--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 TASK_TALLY_BACKEND=http://localhost:8080
 
 KEYCLOAK_URL=http://localhost:8080
-KEYCLOAK_REALM=<your-realm>
-KEYCLOAK_CLIENT_ID=<your-spa-client-id>
+KEYCLOAK_REALM=task-tally-realm
+KEYCLOAK_CLIENT_ID=task-tally
 KEYCLOAK_SILENT_CHECK_PATH=/silent-check-sso.html
 KEYCLOAK_ONLOAD=check-sso
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,24 @@ npm run bundle-profile:analyze
 npm run start
 ```
 
+## Authentication
+
+This project uses [Keycloak](https://www.keycloak.org/) for authentication. To develop locally:
+
+1. Start a Keycloak server and create a public OpenID Connect client with **Standard Flow** and **PKCE S256** enabled.
+2. Set the client's **Valid Redirect URIs** to `http://localhost:9000/*` and **Web Origins** to `http://localhost:9000`.
+3. Create a `.env` file based on `.env.example` with the following keys:
+
+   ```env
+   KEYCLOAK_URL=http://localhost:8080
+   KEYCLOAK_REALM=<your-realm>
+   KEYCLOAK_CLIENT_ID=<your-spa-client-id>
+   KEYCLOAK_SILENT_CHECK_PATH=/silent-check-sso.html
+   KEYCLOAK_ONLOAD=check-sso
+   ```
+
+The development server serves `public/silent-check-sso.html` at `/silent-check-sso.html` for silent SSO during startup.
+
 ## Configurations
 * [TypeScript Config](./tsconfig.json)
 * [Webpack Config](./webpack.common.js)

--- a/__mocks__/keycloak-js.ts
+++ b/__mocks__/keycloak-js.ts
@@ -1,0 +1,14 @@
+export default class Keycloak {
+  token?: string;
+  tokenParsed?: Record<string, unknown>;
+  init = jest.fn().mockResolvedValue(false);
+  login = jest.fn();
+  logout = jest.fn();
+  updateToken = jest.fn().mockResolvedValue(true);
+  onAuthSuccess?: () => void;
+  onAuthError?: () => void;
+  onAuthRefreshSuccess?: () => void;
+  onAuthLogout?: () => void;
+  onTokenExpired?: () => void;
+}
+

--- a/src/api/credentials/service.ts
+++ b/src/api/credentials/service.ts
@@ -1,9 +1,10 @@
 import { CredentialDto, SshKeyCreateRequest } from './types';
+import { apiFetch } from '@app/utils/api';
 
 const BASE = process.env.TASK_TALLY_BACKEND || '/api';
 
 export const listSshKeys = async (userId: string): Promise<CredentialDto[]> => {
-  const res = await fetch(`${BASE}/api/users/${userId}/ssh-keys`);
+  const res = await apiFetch(`${BASE}/api/users/${userId}/ssh-keys`);
   if (!res.ok) {
     throw new Error('Failed to fetch SSH keys');
   }
@@ -11,7 +12,7 @@ export const listSshKeys = async (userId: string): Promise<CredentialDto[]> => {
 };
 
 export const createSshKey = async (userId: string, req: SshKeyCreateRequest): Promise<void> => {
-  const res = await fetch(`${BASE}/api/users/${userId}/ssh-keys`, {
+  const res = await apiFetch(`${BASE}/api/users/${userId}/ssh-keys`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(req),
@@ -22,7 +23,7 @@ export const createSshKey = async (userId: string, req: SshKeyCreateRequest): Pr
 };
 
 export const deleteSshKey = async (userId: string, name: string): Promise<void> => {
-  const res = await fetch(`${BASE}/api/users/${userId}/ssh-keys/${encodeURIComponent(name)}`, {
+  const res = await apiFetch(`${BASE}/api/users/${userId}/ssh-keys/${encodeURIComponent(name)}`, {
     method: 'DELETE',
   });
   if (!res.ok) {

--- a/src/app/LandingPage/LandingPage.tsx
+++ b/src/app/LandingPage/LandingPage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { Bullseye, Button, Stack, StackItem, Title } from '@patternfly/react-core';
-import { GoogleIcon } from '@patternfly/react-icons';
 import { useAuth } from '@app/utils/AuthContext';
 
 const LandingPage: React.FunctionComponent = () => {
@@ -9,17 +8,17 @@ const LandingPage: React.FunctionComponent = () => {
     <div
       className="pf-c-background-image"
       style={{
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "center",
-        alignItems: "center",
-        minHeight: "100vh",
-        color: "#fff",
-        textAlign: "center",
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        alignItems: 'center',
+        minHeight: '100vh',
+        color: '#fff',
+        textAlign: 'center',
         backgroundImage: `url(${background})`,
-        backgroundSize: "cover",
-        backgroundPosition: "center",
-        backgroundRepeat: "no-repeat"
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
       }}
     >
       <Bullseye>
@@ -35,8 +34,8 @@ const LandingPage: React.FunctionComponent = () => {
             </Title>
           </StackItem>
           <StackItem>
-            <Button icon={<GoogleIcon />} variant="primary" size="lg" onClick={login}>
-              Sign in with Google
+            <Button variant="primary" size="lg" onClick={login}>
+              Sign in
             </Button>
           </StackItem>
         </Stack>

--- a/src/app/__snapshots__/app.test.tsx.snap
+++ b/src/app/__snapshots__/app.test.tsx.snap
@@ -48,26 +48,9 @@ exports[`App tests should render landing page when unauthenticated 1`] = `
             type="button"
           >
             <span
-              class="pf-v6-c-button__icon pf-m-start"
-            >
-              <svg
-                aria-hidden="true"
-                class="pf-v6-svg"
-                fill="currentColor"
-                height="1em"
-                role="img"
-                viewBox="0 0 488 512"
-                width="1em"
-              >
-                <path
-                  d="M488 261.8C488 403.3 391.1 504 248 504 110.8 504 0 393.2 0 256S110.8 8 248 8c66.8 0 123 24.5 166.3 64.9l-67.5 64.9C258.5 52.6 94.3 116.6 94.3 256c0 86.5 69.1 156.6 153.7 156.6 98.2 0 135-70.4 140.8-106.9H248v-85.3h236.1c2.3 12.7 3.9 24.9 3.9 41.4z"
-                />
-              </svg>
-            </span>
-            <span
               class="pf-v6-c-button__text"
             >
-              Sign in with Google
+              Sign in
             </span>
           </button>
         </div>

--- a/src/app/app.test.tsx
+++ b/src/app/app.test.tsx
@@ -9,7 +9,7 @@ describe('App tests', () => {
     const { asFragment } = render(<App />);
 
     expect(screen.getByRole('heading', { name: 'Task Tally' })).toBeVisible();
-    expect(screen.getByRole('button', { name: /sign in with google/i })).toBeVisible();
+    expect(screen.getByRole('button', { name: /sign in/i })).toBeVisible();
     expect(asFragment()).toMatchSnapshot();
   });
 

--- a/src/app/utils/api.ts
+++ b/src/app/utils/api.ts
@@ -1,0 +1,17 @@
+import { keycloak } from '@app/utils/AuthContext';
+
+export const apiFetch = async (input: RequestInfo | URL, init: RequestInit = {}): Promise<Response> => {
+  try {
+    await keycloak.updateToken(30);
+  } catch (e) {
+    keycloak.login();
+    throw e;
+  }
+
+  const headers = new Headers(init.headers || {});
+  if (keycloak.token) {
+    headers.set('Authorization', `Bearer ${keycloak.token}`);
+  }
+
+  return fetch(input, { ...init, headers });
+};

--- a/src/app/utils/instrumentation.ts
+++ b/src/app/utils/instrumentation.ts
@@ -1,17 +1,4 @@
-declare global {
-  interface Window {
-    google?: any;
-  }
-}
-
-export function verifyGisInit(clientId: string) {
-  const ready = !!window.google?.accounts?.id;
-  console.groupCollapsed('[GIS] Init check');
-  console.log('GIS script loaded?', ready);
-  console.log('Origin:', window.location.origin);
-  console.log('Client ID present?', !!clientId, clientId?.slice(0, 12) + '…');
-  console.groupEnd();
-}
+export {};
 
 const _fetch = window.fetch;
 window.fetch = async (...args) => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from '@app/index';
-import { verifyGisInit } from '@app/utils/instrumentation';
+import '@app/utils/instrumentation';
 
 if (process.env.NODE_ENV !== 'production') {
   const config = {
@@ -16,7 +16,6 @@ if (process.env.NODE_ENV !== 'production') {
   const axe = require('react-axe');
   axe(React, ReactDOM, 1000, config);
 }
-verifyGisInit(process.env.GOOGLE_CLIENT_ID || '');
 
 const root = ReactDOM.createRoot(document.getElementById('root') as Element);
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,7 @@
     "lib": ["es6", "dom"],
     "sourceMap": true,
     "jsx": "react",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "forceConsistentCasingInFileNames": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -118,7 +118,10 @@ module.exports = () => {
         silent: true,
       }),
       new CopyPlugin({
-        patterns: [{ from: './src/favicon.png', to: 'images' }],
+        patterns: [
+          { from: './src/favicon.png', to: 'images' },
+          { from: './public', to: '.' },
+        ],
       }),
     ],
     resolve: {


### PR DESCRIPTION
## Summary
- integrate Keycloak-backed auth context with token refresh and mock support
- add API helper to inject bearer token and remove Google-specific login
- document Keycloak setup and copy public assets for silent SSO

## Testing
- `npm run format`
- `npm run lint`
- `npm run type-check`
- `npm test -- -u`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a2596c052c832db13f42edf46431b6